### PR TITLE
Add not_found method to Shortcuts

### DIFF
--- a/examples/restful.cr
+++ b/examples/restful.cr
@@ -16,7 +16,7 @@ class PostController
     end
     post = Post.new req.post["text"]
     @posts << post
-    Response.new(201, 
+    Response.new(201,
       "{ message : 'Post created successfully' }",
     )
   end
@@ -31,11 +31,10 @@ class PostController
     @posts.each do |post|
       if post.id == id
         return Response.new(200,
-          post.to_s) 
+          post.to_s)
       end
     end
-    return Response.new(404,
-      "{ message : 'Post id #{id} not found on the server'")
+    return not_found("{ message : 'Post id #{id} not found on the server'}")
   end
 
   def delete(req : Request)
@@ -63,7 +62,7 @@ class Post
   @@postcount = 0
   def initialize(@text)
     @@postcount += 1
-    @id = @@postcount 
+    @id = @@postcount
   end
 
   def to_s
@@ -76,8 +75,8 @@ postCtrl = PostController.new # Instantiate controller
 
 routes = {
   "GET /posts" =>
-    ->(req : Request) { 
-      postCtrl.get_all(req) 
+    ->(req : Request) {
+      postCtrl.get_all(req)
     },
   "POST /posts" =>
     -> (req : Request) {

--- a/src/moonshine/app.cr
+++ b/src/moonshine/app.cr
@@ -1,6 +1,7 @@
 require "http"
 require "regex"
 include Moonshine::Http
+include Moonshine::Shortcuts
 
 class Moonshine::App
   # Base class for Moonshine app
@@ -19,7 +20,7 @@ class Moonshine::App
     @logger = Moonshine::Logger.new
     # add default 404 handler
     error_handler 404, do |req|
-      Response.new(404, "Page not found")
+      not_found("Page not found")
     end
   end
 
@@ -52,7 +53,7 @@ class Moonshine::App
     end
   end
 
-  # Add request middleware. If handler returns a 
+  # Add request middleware. If handler returns a
   # response, no further handlers are called.
   # If nil is returned, the next handler is run
   def request_middleware(&block : Request -> MiddlewareResponse)
@@ -105,7 +106,7 @@ class Moonshine::BaseHTTPHandler < HTTP::Handler
     @response_middleware = [] of (Request, Response) -> Response)
     # add default 404 handler if it isn't there
     unless @error_handlers.has_key? 404
-      @error_handlers[404] = ->(request : Request) { Response.new(404, "Not found")}
+      @error_handlers[404] = ->(request : Request) { not_found("Not found")}
     end
   end
 
@@ -129,7 +130,7 @@ class Moonshine::BaseHTTPHandler < HTTP::Handler
           # controller found
           request.set_params(route.get_params(request))
           response = block.call(request)
-          
+
           # check if there's an error handler defined
           if response.status_code >= 400 && @error_handlers.has_key? response.status_code
             response = @error_handlers[response.status_code].call(request)
@@ -144,7 +145,7 @@ class Moonshine::BaseHTTPHandler < HTTP::Handler
       @static_dirs.each do |dir|
         filepath = File.join(dir, request.path)
         if File.exists?(filepath)
-          response = Response.new(200, File.read(filepath), 
+          response = Response.new(200, File.read(filepath),
             HTTP::Headers{"Content-Type": mime_type(filepath)})
         end
       end

--- a/src/moonshine/shortcuts.cr
+++ b/src/moonshine/shortcuts.cr
@@ -1,9 +1,13 @@
 module Moonshine::Shortcuts
-  
+
   # Returns a Moonshine::Response object
   # from string
   def ok(body)
     Moonshine::Http::Response.new(200, body)
+  end
+
+  def not_found(msg=nil)
+    Moonshine::Http::Response.new(404, msg)
   end
 
   # Returns a Redirect response to the specified


### PR DESCRIPTION
Add not_found() method to Moonshone::Shortcuts, and code changed to use it instead  Response.new(404).
