### PR TITLE
test against Crystal nightly on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: crystal
+crystal:
+  - latest
+  - nightly
+matrix:
+  allow_failures:
+    - crystal: nightly
 branches:
   only:
     - master


### PR DESCRIPTION
Moonshine is still a highly ranked Crystal project. It would be good if it kept up with the latest compiler releases, so people trying out the language don't get a bad first impression. We hope that providing nightlies on Travis CI will make that easier for you.
